### PR TITLE
BREAK: modernizing code and api

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ Makefile
 *.log
 .nyc_output/
 examples/
+tsconfig.json

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 [![NPM version](https://badge.fury.io/js/streamss-through.svg)](https://www.npmjs.com/package/streamss-through/)
 [![Build Status](https://secure.travis-ci.org/commenthol/streamss-through.svg?branch=master)](https://travis-ci.org/commenthol/streamss-through)
 
-Works with node v0.8.x and greater.
-For node v0.8.x the user-land copy [readable-stream][] is used.
-For all other node versions greater v0.8.x the built-in `stream` module is used.
+Works with node v8.x and greater.
 
 `Through` can be used in synchronous mode with:
 
-```javascript
+```js
+const { through } = require('streamss-through')
+
 process.stdin
-.pipe(Through(
+.pipe(through(
   function transform (data){
     // synchronous mode
   },
@@ -25,16 +25,18 @@ process.stdin
 
 or in asynchronous mode:
 
-```javascript
+```js
+const { through } = require('streamss-through')
+
 process.stdin
-.pipe(Through(
+.pipe(through(
   function transform (data, enc, done){
     // asynchronous mode
-    done(); // explicit call of done required
+    done() // explicit call of done required
   },
   function flush (done){
     // asynchronous mode
-    done(); // explicit call of done required
+    done() // explicit call of done required
   }
 ))
 ```
@@ -52,7 +54,7 @@ process.stdin
 - `{Function} transform` - Function called on transform
 - `{Function} flush` - Function called on flush
 
-## Through.obj([options], transform, flush)
+## throughObj([options], transform, flush)
 
 > Shortcut for object mode
 
@@ -66,21 +68,21 @@ process.stdin
 ### Example:
 
 ```javascript
-var Through = require('streamss-through');
-var cnt = 0;
+const { through } = require('streamss-through')
+let cnt = 0
 
 require('fs').createReadStream(__filename, { encoding: 'utf8', highWaterMark: 30 })
-.pipe(Through(
+.pipe(through(
   { decodeStrings: false },
   function transform(str) {
-    cnt += 1;
-    this.push(str.replace(/\s/g, '‧') + '\n');
+    cnt += 1
+    this.push(str.replace(/\s/g, '‧') + '\n')
   },
   function flush() {
-    console.log('\ncounted num of chunks: ' + cnt);
+    console.log('\ncounted num of chunks: ' + cnt)
   }
 ))
-.pipe(process.stdout);
+.pipe(process.stdout)
 ```
 
 Try it with:
@@ -105,4 +107,3 @@ Copyright (c) 2014- Commenthol. (MIT License)
 See [LICENSE][] for more info.
 
 [LICENSE]: ./LICENSE
-[readable-stream]: https://github.com/isaacs/readable-stream

--- a/examples/test.js
+++ b/examples/test.js
@@ -1,8 +1,8 @@
-var Through = require('..')
-var cnt = 0
+const { through } = require('..')
+let cnt = 0
 
 require('fs').createReadStream(__filename, { encoding: 'utf8', highWaterMark: 30 })
-  .pipe(Through(
+  .pipe(through(
     { decodeStrings: false },
     function transform (str) {
       cnt += 1

--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
   "license": "MIT",
   "author": "commenthol <commenthol@gmail.com>",
   "main": "index.js",
+  "typings": "types",
   "directories": {
+    "example": "examples",
     "test": "test"
   },
   "scripts": {
     "all": "npm run clean && npm run lint && npm test",
+    "build:tsc": "tsc --build types; find types -iname '*.js' -exec rm '{}' \\;",
     "clean": "rimraf coverage .nyc_output",
     "clean:all": "rimraf node_modules && npm run clean",
     "coverage": "nyc -r text -r html npm test",
@@ -52,7 +55,8 @@
     "eslint-plugin-standard": "^4.0.1",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
-    "rimraf": "^3.0.0"
+    "rimraf": "^3.0.0",
+    "typescript": "^3.7.2"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -27,11 +27,15 @@
     "clean:all": "rimraf node_modules && npm run clean",
     "coverage": "nyc -r text -r html npm test",
     "doc": "jsdoc -d doc -c jsdoc.json index.js",
-    "lint": "eslint '**/*.js'",
+    "lint": "eslint --fix \"**/*.js\"",
     "prepublishOnly": "npm run all",
     "test": "mocha"
   },
   "eslintConfig": {
+    "env": {
+      "node": true,
+      "mocha": true
+    },
     "extends": "standard",
     "plugins": [
       "standard"
@@ -40,7 +44,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": "^6.5.1",
+    "eslint": "^6.6.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^10.0.0",
@@ -51,7 +55,7 @@
     "rimraf": "^3.0.0"
   },
   "engines": {
-    "node": ">=4.5.0"
+    "node": ">=8.0.0"
   },
   "maintainers": [
     "commenthol <commenthol@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamss-through",
-  "version": "1.0.2",
+  "version": "2.0.0-0",
   "description": "A sync/async stream2 transformer",
   "keywords": [
     "stream2",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,29 @@
+export = Through;
+declare const Through_base: any;
+/**
+ * Stream transformer with functional API
+ *
+ * @constructor
+ * @param {Object} [options] - Stream options
+ * @param {Boolean} options.objectMode - Whether this stream should behave as a stream of objects. Default=false
+ * @param {Number} options.highWaterMark - The maximum number of bytes to store in the internal buffer before ceasing to read from the underlying resource. Default=16kb
+ * @param {String} options.encoding - Set encoding for string-decoder
+ * @param {Boolean} options.decodeStrings - Do not decode strings if set to `false`. Default=true
+ * @param {Boolean} options.passError - Pass error to next pipe. Default=true
+ * @param {Function} [transform] - Function called on transform
+ * @param {Function} [flush] - Function called on flush
+ */
+declare class Through extends Through_base {
+    constructor(options?: Object | Function, transform?: Function, flush?: Function);
+
+    static through(options?: Object | Function, transform?: Function, flush?: Function): Through;
+
+    /**
+     * Shortcut for object mode
+     *
+     * @param {Object} [options] - Stream options
+     * @param {Function} transform - Function called on transform
+     * @param {Function} flush - Function called on flush
+     */
+    static throughObj(options?: Object | Function, transform?: Function, flush?: Function): Through;
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -8,7 +8,7 @@
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,69 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ESNEXT",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "none",                        /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "allowJs": true,                          /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./",                           /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  },
+  "files": [
+    "../index.js"
+  ]
+}


### PR DESCRIPTION
BREAK: modernizing code and api
    
discontinues support for node < 8
uses `through` for static function and `Through` for class
`Trough.obj` became `throughObj`
